### PR TITLE
Issue 65 Fix: Fix Food Filtering & Added Political, Protest events to Filtering options

### DIFF
--- a/components/CategorySelector.js
+++ b/components/CategorySelector.js
@@ -16,10 +16,12 @@ const CategorySelector = (props) => {
             <FlatList
                 data={[
                     { type: "Party", id: "party" },
-                    { type: "Food", id: "Food" },
+                    { type: "Food", id: "food" },
                     { type: "Music", id: "music" },
                     { type: "Sports", id: "sports" },
                     { type: "Meeting", id: "meeting" },
+                    { type: "Political", id: "political" },
+                    { type: "Protest", id: "protest" },
                 ]}
                 renderItem={({ item }) =>
                     <ListItem noIndent onPress={() => {


### PR DESCRIPTION
What was accomplished?
- Fixed food filtering, was filtering by "Food" instead of "food", event categories are supposed to be lower case
- Political and Protest categories added to CategorySelector -> Can filter by these event types now

How was this tested?
- Manual Testing on iOS, ensured other filters work for all event types we have pins for.

New Dependencies?
- No

Issues:
Closes #65 