### PR TITLE
Fix Issue #77, Resetting the user saved and created events on logout

### DIFF
--- a/store/reducers/events.js
+++ b/store/reducers/events.js
@@ -16,7 +16,7 @@ import {
     PEOPLE_GOING,
     SET_DATE_FILTER
 } from '../actions/events';
-import { UPDATE_EVENT } from '../actions/user'
+import { UPDATE_EVENT, LOGOUT } from '../actions/user'
 import { datesAreOnSameDay } from '../../helper/dateHelpers';
 
 const initialState = {
@@ -178,6 +178,12 @@ export default (state = initialState, action) => {
                 ...state,
                 eventGoing: action.eventGoing
             };
+        case LOGOUT:
+            return {
+                ...state,
+                createdEvents: [],
+                savedEvents: []
+            }
         default:
             return state;
     }


### PR DESCRIPTION
What was accomplished?
- Reset the created and Saved events on logout, only reset going events before

How was this tested?
- Logged in, saw all my created and saved events. then I logged out and confirmed that they were gone.

New Dependencies?
- Nope!

Resolves #77