### PR TITLE
Ms/87 - Resolved cut off on User Going Screen icon on Event Screen

### DIFF
--- a/helper/createEventHelper.js
+++ b/helper/createEventHelper.js
@@ -20,7 +20,7 @@ export const combineDateAndTime = (date, time) => {
 	return dateTime;
 };
 
-export const stringifyDate = (date) => {
+export const stringifyDate = (date, newLine) => {
 	var dd = date.getDate();
 	var mm = date.getMonth() + 1;
 	var yyyy = date.getFullYear();
@@ -42,7 +42,11 @@ export const stringifyDate = (date) => {
 		case 6: weekDay = "Saturday"; break;
 		default: weekDay = ""; break;
 	}
-	return weekDay + ", " + mm + "/" + dd + "/" + yyyy;
+	if (newLine) {
+		return weekDay + ",\n" + mm + "/" + dd + "/" + yyyy;
+	} else {
+		return weekDay + ", " + mm + "/" + dd + "/" + yyyy;
+	}
 };
 
 export const stringifyDateShort = (date) => {

--- a/screens/events/EventScreen.js
+++ b/screens/events/EventScreen.js
@@ -167,7 +167,7 @@ const EventScreen = (props) => {
 							</Text>
 						)}
 					<Text style={{ fontSize: 20, color: "black", textAlign: 'right' }}>
-						{stringifyDate(new Date(event.date))}
+					{stringifyDate(new Date(event.date), true) /*2nd arg tells us to put day name above date*/ } 
 					</Text>
 				</Right>
 			</View>
@@ -190,8 +190,8 @@ const EventScreen = (props) => {
 								paddingHorizontal: 15,
 							}}
 						>
-							<TouchableOpacity style={{ flexDirection: 'row', alignItems: 'center' }} onPress={navigateToGoingList}>
-								<VectorIcon name="persona" type='Zocial' style={{ color: Colors.purpleButton, paddingRight: 10 }} />
+							<TouchableOpacity style={{ flexDirection: 'row', alignItems: 'center'}} onPress={navigateToGoingList}>
+								<VectorIcon name="ios-people" style={{ color: Colors.purpleButton, paddingRight: 5, fontSize: 35 }} />
 								<Text style={styles.goingText}> {numGoing} Going</Text>
 							</TouchableOpacity>
 							{userName != event.host.name && userName ? (


### PR DESCRIPTION
What was accomplished?
-
- Swapped out buggy icon for one that is not
- Icon better resembles what it links to

How was this tested?
-
- Tested manually on iOS and Android emulator -> icon renders correctly

New Dependencies?
-
- Nope!

Pics
-
#### Android
![Screen Shot 2020-08-14 at 2 19 42 PM](https://user-images.githubusercontent.com/25811429/90280812-8d19c580-de39-11ea-8604-0021801d4481.png)
#### iOS
<img width="295" alt="Screen Shot 2020-08-14 at 2 22 56 PM" src="https://user-images.githubusercontent.com/25811429/90280887-a7ec3a00-de39-11ea-8189-5aed521540c2.png">


Closes #87 