### PR TITLE
ms/96 - Save and Going Buttons on Event Screen now displaying correct state

### DIFF
--- a/screens/events/EventScreen.js
+++ b/screens/events/EventScreen.js
@@ -35,8 +35,7 @@ const EventScreen = (props) => {
 	const goingEvents = useSelector((state) => state.user.goingEvents);
 	const event = props.navigation.getParam("event");
 	const [numGoing, setNumGoing] = useState(event.attending);
-	const [isEventSaved, setEventSaved] = useState(initialEventSaveState);
-	const [isGoing, setGoing] = useState(initialEventGoingState);
+	
 	const dispatch = useDispatch();
 
 	console.log("this is the event " + JSON.stringify(event));
@@ -63,6 +62,8 @@ const EventScreen = (props) => {
 	} else {
 		initialEventGoingState = false;
 	}
+	const [isEventSaved, setEventSaved] = useState(initialEventSaveState);
+	const [isGoing, setGoing] = useState(initialEventGoingState);
 
 	// Setup deep link for address
 	const scheme = Platform.select({ ios: 'maps:0,0?q=', android: 'geo:0,0?q=' });


### PR DESCRIPTION
What was accomplished?
-
- Fixed the going and saved button to pull in the correct state, and look selected if they have been previously

How was this tested?
-
- Manual testing to confirm that the saved/going state was pulled in correctly when event was/wasn't saved and/or going

New Dependencies?
-
- Nope!

Pics
-
#### Event Screen Now pulling in correct state
![Screen Shot 2020-08-14 at 3 14 43 PM](https://user-images.githubusercontent.com/25811429/90284948-e2a5a080-de40-11ea-9c69-1593841d51b4.png)


Closed #96 